### PR TITLE
next_token unbound after exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 *.egg
 .coverage
 htmlcov/
+.ropeproject

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ awslogs is mainly developed and maintained by Jorge Bastida <me@jorgebastida.com
 
 A big thanks to all the contributors:
 Angel Abad <angelabad@gmail.com>
+Álex González <agonzalezro@gmail.com>

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -130,6 +130,7 @@ class AWSLogs(object):
             except Empty:
                 if self.watch:
                     gevent.sleep(self.WATCH_SLEEP)
+                    continue
                 else:
                     break
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     platforms='any',
     install_requires=install_requires,
     test_suite='tests',
+    tests_require=tests_require,
     classifiers=[
         'Programming Language :: Python :: 2',
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
The var `next_token` is not going to be defined if the `Empty` exception occurs.

Wait for the `gevent.sleep` and continue with the next iteration of the loop.