### PR TITLE
Add note for installing on El Capitan

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,9 @@ You can easily install ``awslogs`` using ``pip``::
 
   $ pip install awslogs
 
+If you are on OSX El Capitan, use the following::
+
+  $ pip install awslogs --ignore-installed six
 
 Options
 -------


### PR DESCRIPTION
It appears that there's an issue with six that causes problems [installing on OSX El Capitan](https://github.com/pypa/pip/issues/3165#issuecomment-146966939).  This updates README to include install notes for El Capitan.