### PR TITLE
Ensures that awslogs terminates on keyboard interrupt and systemexit …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ awslogs is mainly developed and maintained by Jorge Bastida <me@jorgebastida.com
 A big thanks to all the contributors:
 Angel Abad <angelabad@gmail.com>
 Álex González <agonzalezro@gmail.com>
+Eric Hayes <ejhayes@jacobianengineering.com>

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -10,7 +10,7 @@ from . import exceptions
 from .core import AWSLogs
 
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 
 def main(argv=None):

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import os
 import time
 from threading import Thread, Event
 from datetime import datetime, timedelta
@@ -163,9 +164,9 @@ class AWSLogs(object):
                 time.sleep(.1)
         except (KeyboardInterrupt, SystemExit):
             exit.set()
-            print('You pressed Ctrl+C!\n')
-            g.join()
-            c.join()
+            print('Closing...\n')
+            os._exit(0)
+            
 
     def list_groups(self):
         """Lists available CloudWatch logs groups"""


### PR DESCRIPTION
I ran into some problems trying to terminate this tool with `Ctrl + C`.  In order to ensure that the tool terminates each time I am doing an OS exit (returning 0 since everything is ok).

This issue appears to be noted in #21.