### PR TITLE
Replacing max int with max float for window_end

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -166,7 +166,7 @@ class AWSLogs(object):
             exit.set()
             print('Closing...\n')
             os._exit(0)
-            
+
 
     def list_groups(self):
         """Lists available CloudWatch logs groups"""
@@ -189,7 +189,7 @@ class AWSLogs(object):
         """Returns available CloudWatch logs streams in ``log_group_name``."""
         kwargs = {'logGroupName': log_group_name or self.log_group_name}
         window_start = self.start or 0
-        window_end = self.end or sys.maxsize
+        window_end = self.end or sys.float_info.max
 
         paginator = self.client.get_paginator('describe_log_streams')
         for page in paginator.paginate(**kwargs):


### PR DESCRIPTION
On Python 2.7.10 on Windows 10 x64, `sys.maxsize` is only 2147483647, which is a lot smaller than the timestamps. Using the max float value instead fixes it.

An obvious workaround is to supply `--end="0s ago"`.