### PR TITLE
No 'func' on argparse in Python 3 when no arguments provided

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -118,6 +118,9 @@ def main(argv=None):
 
     try:
         logs = AWSLogs(**vars(options))
+        if not hasattr(options, 'func'):
+            parser.print_help()
+            return 1
         getattr(logs, options.func)()
     except ClientError as exc:
         code = exc.response['Error']['Code']


### PR DESCRIPTION
On Python 3.5.0:

```
(awslogs)[philip@laptop awslogs]$ awslogs

================================================================================
You've found a bug! Please, raise an issue attaching the following traceback
https://github.com/jorgebastida/awslogs/issues/new
--------------------------------------------------------------------------------
Version: 0.1.2
Python: 3.5.0 (default, Oct  7 2015, 17:45:40) 
[GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)]
boto3 version: 1.2.2
Platform: Darwin-14.5.0-x86_64-i386-64bit
Config: {'aws_secret_access_key': 'SENSITIVE', 'aws_session_token': 'SENSITIVE', 'aws_access_key_id': 'SENSITIVE'}
Args: ['/Users/philip/.pyenv/versions/awslogs/bin/awslogs']

Traceback (most recent call last):
  File "/Users/philip/projects/python/awslogs/awslogs/bin.py", line 121, in main
    getattr(logs, options.func)()
AttributeError: 'Namespace' object has no attribute 'func'
================================================================================
```

On Python 2.7.10:

```
[philip@laptop awslogs]$ awslogs
usage: awslogs [ get | groups | streams ]
awslogs: error: too few arguments
```
