### PR TITLE
Replace broken image and link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ awslogs
 .. image:: https://coveralls.io/repos/jorgebastida/awslogs/badge.svg
   :target: https://coveralls.io/r/jorgebastida/awslogs
 
-.. image:: https://pypip.in/d/awslogs/badge.png
-  :target: https://crate.io/packages/awslogs/
+.. image:: https://img.shields.io/pypi/dm/awslogs.svg
+  :target: https://pypi.python.org/pypi/awslogs/
 
 
 ``awslogs`` is a simple command line tool for querying groups, streams and events from `Amazon CloudWatch <http://aws.amazon.com/cloudwatch/>`_ logs.


### PR DESCRIPTION
pypip.in is down, possibly forever, and crate.io reports a 410 for the awslogs package. This replaces the image with one from shields.io and links to pypi.