### PR TITLE
Catch the exception and encode the output string

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -128,7 +128,11 @@ class AWSLogs(object):
                         )
                     )
                 output.append(event['message'])
-                print(' '.join(output))
+                joined_output = ' '.join(output)
+                try:
+                    print(joined_output)
+                except UnicodeEncodeError:
+                    print(joined_output.encode('utf-8'))
 
         def generator():
             """Push events into queue trying to deduplicate them using a lru queue.


### PR DESCRIPTION
When the output is redirected to another program or file then Python 2.x throws a `UnicodeEncodeError`, as reported in #44.

This change catches the exception and encodes the output as utf-8.