### PR TITLE
If no streams are found don't fallback on all.

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -148,8 +148,7 @@ class AWSLogs(object):
             kwargs = {'logGroupName': self.log_group_name,
                       'interleaved': True}
 
-            if streams:
-                kwargs['logStreamNames'] = streams
+            kwargs['logStreamNames'] = streams
 
             if self.start:
                 kwargs['startTime'] = self.start


### PR DESCRIPTION
 Do not fallback on all available streams if none are found when performing pattern matching.