### PR TITLE
`awslogs get`: inform user if no streams match pattern

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -80,6 +80,8 @@ class AWSLogs(object):
                      len(streams),
                      self.FILTER_LOG_EVENTS_STREAMS_LIMIT
                 )
+            if len(streams) == 0:
+                raise exceptions.NoStreamsFilteredError(self.log_stream_name)
 
         max_stream_length = max([len(s) for s in streams]) if streams else 10
         group_length = len(self.log_group_name)

--- a/awslogs/exceptions.py
+++ b/awslogs/exceptions.py
@@ -19,7 +19,15 @@ class TooManyStreamsFilteredError(BaseAWSLogsException):
     code = 6
 
     def hint(self):
-        return ("The number of streams that match your patter '{0}' is '{1}'. "
+        return ("The number of streams that match your pattern '{0}' is '{1}'. "
                 "AWS API limits the number of streams you can filter by to {2}."
                 "It might be helpful to you to not filter streams by any "
                 "pattern and filter the output of awslogs.").format(*self.args)
+
+
+class NoStreamsFilteredError(BaseAWSLogsException):
+
+    code = 7
+
+    def hint(self):
+        return ("No streams match your pattern '{0}'.").format(*self.args)

--- a/tests.py
+++ b/tests.py
@@ -385,6 +385,38 @@ class TestAWSLogs(unittest.TestCase):
         )
 
     @patch('boto3.client')
+    @patch('sys.stderr', new_callable=StringIO)
+    def test_main_get_no_matching_streams(self, mock_stderr, botoclient):
+        client = Mock()
+        botoclient.return_value = client
+
+        groups = [
+            {'logGroups': [{'logGroupName': 'AAA'}]},
+        ]
+
+        # None of these match the pattern below: "foo.*"
+        streams = [
+            {'logStreams': [self._stream('DDD'),
+                            self._stream('EEE')]}
+        ]
+
+        def paginator(value):
+            mock = Mock()
+            mock.paginate.return_value = {
+                'describe_log_groups': groups,
+                'describe_log_streams': streams
+            }.get(value)
+            return mock
+
+        client.get_paginator.side_effect = paginator
+
+        code = main("awslogs get AAA foo.*".split())
+        self.assertEqual(code, 7)
+        self.assertEqual(mock_stderr.getvalue(),
+                         colored("No streams match your pattern 'foo.*'.\n",
+                                 "red"))
+
+    @patch('boto3.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_groups(self, mock_stdout, botoclient):
         client = Mock()


### PR DESCRIPTION
Resolves:
https://github.com/jorgebastida/awslogs/issues/52

Previously, given a query like:
```
$ python run.py get my-log-group my-pattern.*
```

if no streams matched `my-pattern.*` then results from all streams would
be returned.

Now the user sees an error message if no streams match their pattern:

```
$ python run.py get my-log-group my-pattern.*
No streams match your pattern 'my-pattern.*'.
```