### PR TITLE
Refresh streams while watching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ python:
     - 3.3
     - 3.4
 install:
-    - pip install tox-travis
-    - pip install coveralls
+    - pip install tox-travis coveralls
 script:
- - tox
+    - tox -- -sv
 after_success:
-  - coveralls
+    - coveralls

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -9,6 +9,7 @@ try:
     from Queue import Queue
 except ImportError:
     from queue import Queue
+import warnings
 
 import boto3
 from botocore.compat import total_seconds
@@ -24,11 +25,18 @@ def milis2iso(milis):
     return (res + ".000")[:23] + 'Z'
 
 
+def generate_spinner():
+    while True:
+        for cursor in '|/-\\':
+            yield cursor
+
+
 class AWSLogs(object):
 
     ACTIVE = 1
     EXHAUSTED = 2
     WATCH_SLEEP = 2
+    WATCH_STREAM_SLEEP = 5
 
     FILTER_LOG_EVENTS_STREAMS_LIMIT = 100
     MAX_EVENTS_PER_CALL = 10000
@@ -68,23 +76,28 @@ class AWSLogs(object):
             if re.match(reg, stream):
                 yield stream
 
-    def list_logs(self):
-        streams = []
+    def _get_streams_for_list_logs(self):
         if self.log_stream_name != self.ALL_WILDCARD:
             streams = list(self._get_streams_from_pattern(self.log_group_name, self.log_stream_name))
-            if len(streams) > self.FILTER_LOG_EVENTS_STREAMS_LIMIT:
-                raise exceptions.TooManyStreamsFilteredError(
-                     self.log_stream_name,
-                     len(streams),
-                     self.FILTER_LOG_EVENTS_STREAMS_LIMIT
-                )
-            if len(streams) == 0:
-                raise exceptions.NoStreamsFilteredError(self.log_stream_name)
+        else:
+            streams = list(self.get_streams(self.log_group_name))
 
+        if not self.watch and len(streams) == 0:
+            raise exceptions.NoStreamsFilteredError(self.log_stream_name)
+
+        if len(streams) >= self.FILTER_LOG_EVENTS_STREAMS_LIMIT:
+            warnings.warn('Max number of streams limit reached.'
+                          ' You might want to narrow down your filtering.')
+        return streams
+
+    def list_logs(self):
+        streams = self._get_streams_for_list_logs()[:self.FILTER_LOG_EVENTS_STREAMS_LIMIT]
         max_stream_length = max([len(s) for s in streams]) if streams else 10
         group_length = len(self.log_group_name)
 
         queue, exit = Queue(), Event()
+        # XXX expose exit event on AWSLogs instance for testing.
+        self.exit = exit
 
         # Note: filter_log_events paginator is broken
         # ! Error during pagination: The same next token was received twice
@@ -130,6 +143,19 @@ class AWSLogs(object):
                 output.append(event['message'])
                 print(' '.join(output))
 
+        def refresh_streams():
+            """
+            Refresh the list of streams every 5s.
+            Because some new streams might appear during
+            watching process.
+            """
+            if not self.watch:
+                return
+            while not exit.is_set():
+                # Refresh the same shared `streams` list object.
+                streams[:] = self._get_streams_for_list_logs()[:self.FILTER_LOG_EVENTS_STREAMS_LIMIT]
+                time.sleep(self.WATCH_STREAM_SLEEP)
+
         def generator():
             """Push events into queue trying to deduplicate them using a lru queue.
             AWS API stands for the interleaved parameter that:
@@ -148,8 +174,7 @@ class AWSLogs(object):
             kwargs = {'logGroupName': self.log_group_name,
                       'interleaved': True}
 
-            if streams:
-                kwargs['logStreamNames'] = streams
+            kwargs['logStreamNames'] = streams
 
             if self.start:
                 kwargs['startTime'] = self.start
@@ -160,15 +185,32 @@ class AWSLogs(object):
             if self.filter_pattern:
                 kwargs['filterPattern'] = self.filter_pattern
 
+            spinner = generate_spinner()
+            already_spinning = False
+            previous_length = len(kwargs['logStreamNames'])
             while not exit.is_set():
-                response = self.client.filter_log_events(**kwargs)
+                if not kwargs['logStreamNames']:
+                    # don't fetch logs when we don't have streams
+                    # loop until streams are found.
+                    if not already_spinning:
+                        print('No streams found, waiting:')
+                        already_spinning = True
+                    sys.stdout.write('\b{0}'.format(next(spinner)))
+                    sys.stdout.flush()
+                    time.sleep(1)
+                    continue
+                else:
+                    already_spinning = False
 
+                response = self.client.filter_log_events(**kwargs)
                 for event in response.get('events', []):
                     if event['eventId'] not in interleaving_sanity:
                         interleaving_sanity.append(event['eventId'])
                         queue.put(event)
-
-                if 'nextToken' in response:
+                length = len(kwargs['logStreamNames'])
+                if 'nextToken' in response and previous_length == length:
+                    # Use nexToken only when the list of streams remain the
+                    # same.
                     kwargs['nextToken'] = response['nextToken']
                 else:
                     if self.watch:
@@ -176,11 +218,18 @@ class AWSLogs(object):
                     else:
                         queue.put(None)
                         break
+                previous_length = length
+
+        rs = Thread(target=refresh_streams)
+        rs.daemon = True
+        rs.start()
 
         g = Thread(target=generator)
+        g.daemon = True
         g.start()
 
         c = Thread(target=consumer)
+        c.daemon = True
         c.start()
 
         try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
     packages=find_packages(),
     platforms='any',
     install_requires=install_requires,
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'pytest-mock'],
     test_suite='tests',
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,56 @@
+import datetime as dt
+import functools
+import threading
+import time
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import pytest
+
+
+@pytest.fixture()
+def awslogs(mocker):
+    from awslogs import AWSLogs
+
+    mocker.patch('boto3.client')
+    awslogs = AWSLogs(
+        log_group_name='group',
+        watch=True,
+    )
+    return awslogs
+
+
+def test_watching_refresh_logs_no_stream_found(awslogs, mocker, capsys):
+    """Check that a spinner is displayed when no stream are found."""
+
+    def stop(awslogs):
+        time.sleep(1.1)
+        awslogs.exit.set()
+
+    t1 = threading.Thread(target=functools.partial(stop, awslogs))
+    t1.start()
+    awslogs.list_logs()
+    out, err = capsys.readouterr()
+    assert out == 'No streams found, waiting:\n\b|\b/'
+
+
+def test_watching_refresh_logs(awslogs, mocker, capsys):
+    """
+    Check that refresh_streams is called between WATCH_STREAM_SLEEP interval.
+    """
+
+    awslogs.WATCH_STREAM_SLEEP = .1
+
+    awslogs._get_streams_for_list_logs = mocker.MagicMock(
+        return_value=[['a']])
+
+    def stop(awslogs):
+        time.sleep(awslogs.WATCH_STREAM_SLEEP + .1)
+        awslogs.exit.set()
+
+    t1 = threading.Thread(target=functools.partial(stop, awslogs))
+    t1.start()
+    awslogs.list_logs()
+    awslogs._get_streams_for_list_logs.assert_has_calls([mock.call()] * 3)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = py{26,27,33,34}
 
 [testenv]
 commands =
-    coverage run --source awslogs -m pytest -sv tests []
+    coverage run --source awslogs -m pytest tests {posargs}
     awslogs --help
     coverage report
     flake8 awslogs
@@ -18,6 +18,7 @@ deps =
     coverage
     pytest
     flake8
+    pytest-mock
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
- Add a new Thread to refresh the list of streams, as new streams might appear during watching.
- When no streams matched the pattern, the output display a message `'No streams found, waiting:'`
  It is then up to the user to wait until a stream get returned, or to press `Ctrl+C`, to stop the watching process. fixes #60 
