### PR TITLE
Add -S as shorthand for --no-stream and -G as shorthand for --no-group

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 awslogs is mainly developed and maintained by Jorge Bastida <me@jorgebastida.com>
 
 A big thanks to all the contributors:
+Adam Johnson <me@adamj.eu>
 Angel Abad <angelabad@gmail.com>
 Álex González <agonzalezro@gmail.com>
 Eric Hayes <ejhayes@jacobianengineering.com>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Add ``-S`` as shorthand for ``--no-stream`` and ``-G`` as shorthand for
+  ``--no-group``.
+
 0.4.0
 =====
 * Fix utf-8 issues

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -95,12 +95,14 @@ def main(argv=None):
                             dest='watch',
                             help="Query for new log lines constantly")
 
-    get_parser.add_argument("--no-group",
+    get_parser.add_argument("-G",
+                            "--no-group",
                             action='store_false',
                             dest='output_group_enabled',
                             help="Do not display group name")
 
-    get_parser.add_argument("--no-stream",
+    get_parser.add_argument("-S",
+                            "--no-stream",
                             action='store_false',
                             dest='output_stream_enabled',
                             help="Do not display stream name")

--- a/tests.py
+++ b/tests.py
@@ -280,6 +280,22 @@ class TestAWSLogs(unittest.TestCase):
 
     @patch('boto3.client')
     @patch('sys.stdout', new_callable=StringIO)
+    def test_get_nogroup_nostream_short_forms(self, mock_stdout, botoclient):
+        self.set_ABCDE_logs(botoclient)
+        main("awslogs get -GS AAA DDD --no-color".split())
+
+        self.assertEqual(
+            mock_stdout.getvalue(),
+            ("Hello 1\n"
+             "Hello 2\n"
+             "Hello 3\n"
+             "Hello 4\n"
+             "Hello 5\n"
+             "Hello 6\n")
+        )
+
+    @patch('boto3.client')
+    @patch('sys.stdout', new_callable=StringIO)
     def test_get_timestamp(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
         main("awslogs get "


### PR DESCRIPTION
My logs are in pure json and I don't ever need stream or group, it's getting a bit tiresome to have to type the full flags. By doing this one can just `awslogs get -SG` to pull the plain json for further processing in e.g. `jq`.