### PR TITLE
Flush message output to stdout

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -129,6 +129,7 @@ class AWSLogs(object):
                     )
                 output.append(event['message'])
                 print(' '.join(output))
+                sys.stdout.flush();
 
         def generator():
             """Push events into queue trying to deduplicate them using a lru queue.


### PR DESCRIPTION
The other way this could be handled is running python with the [`-u`](https://docs.python.org/2/using/cmdline.html#cmdoption-u) flag .