### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ While querying for logs you can filter events by ``--start`` ``-s`` and ``--end`
   - ``--start='1/1/2015'`` Events generated after midnight on the 1st of January 2015.
   - ``--start='Sat Oct 11 17:13:46 UTC 2003'`` You can use detailed dates too.
 
-  Note, for time parsing awslogs uses `dateutil <https://dateutil.readthedocs.org/en/latest/>`_.
+  Note, for time parsing awslogs uses `dateutil <https://dateutil.readthedocs.io/en/latest/>`_.
 
 * All previous examples are applicable for  ``--end`` ``-e`` too.
 
@@ -159,7 +159,7 @@ Helpful Links
 -------------
 
 * http://aws.amazon.com/cloudwatch/
-* http://boto.readthedocs.org/en/latest/ref/logs.html
+* https://boto.readthedocs.io/en/latest/ref/logs.html
 * http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html
 
 How to provide AWS credentials to awslogs

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -81,7 +81,7 @@ For that reason, there is no reason to install virtualenv separately.
 
 .. _tox: https://testrun.org/tox/latest/
 
-.. _virtualenvwrapper: http://virtualenvwrapper.readthedocs.org/en/latest/
+.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/
 
 .. _venv: https://docs.python.org/3/library/venv.html
 
@@ -108,7 +108,7 @@ not executed. There are often the lines, where bugs are present.
 
 This project is using coverage_ tool.
 
-.. _coverage: http://coverage.readthedocs.org/en/
+.. _coverage: https://coverage.readthedocs.io/
 
 Recipes
 =======


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.