### PR TITLE
Allow JMES path queries for JSON logs

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -128,10 +128,11 @@ def main(argv=None):
                             dest='color_enabled',
                             help="Do not color output")
 
-    get_parser.add_argument("--query",
+    get_parser.add_argument("-q",
+                            "--query",
                             action="store",
                             dest="query",
-                            help="A JMESPath query to use in filtering the response data, if JSON.")
+                            help="JMESPath query to use in filtering the response data")
 
     # groups
     groups_parser = subparsers.add_parser('groups', description='List groups')

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -128,6 +128,11 @@ def main(argv=None):
                             dest='color_enabled',
                             help="Do not color output")
 
+    get_parser.add_argument("--query",
+                            action="store",
+                            dest="query",
+                            help="A JMESPath query to use in filtering the response data, if JSON.")
+
     # groups
     groups_parser = subparsers.add_parser('groups', description='List groups')
     groups_parser.set_defaults(func="list_groups")

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -6,7 +6,9 @@ from datetime import datetime, timedelta
 from collections import deque
 
 import boto3
-from botocore.compat import total_seconds
+from botocore.compat import json, six, total_seconds
+
+import jmespath
 
 from termcolor import colored
 from dateutil.parser import parse
@@ -46,6 +48,9 @@ class AWSLogs(object):
             'output_ingestion_time_enabled')
         self.start = self.parse_datetime(kwargs.get('start'))
         self.end = self.parse_datetime(kwargs.get('end'))
+        self.query = kwargs.get('query')
+        if self.query is not None:
+            self.query_expression = jmespath.compile(self.query)
 
         self.client = boto3.client(
             'logs',
@@ -166,7 +171,15 @@ class AWSLogs(object):
                             'blue'
                         )
                     )
-                output.append(event['message'].rstrip())
+
+                message = event['message']
+                if self.query is not None and message[0] == '{':
+                    parsed = json.loads(event['message'])
+                    message = self.query_expression.search(parsed)
+                    if not isinstance(message, six.string_types):
+                        message = json.dumps(message)
+                output.append(message)
+
                 print(' '.join(output))
                 sys.stdout.flush()
         try:

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'boto3>=1.2.1',
+    'jmespath>=0.7.1,<1.0.0',
     'termcolor>=1.1.0',
     'python-dateutil>=2.4.0'
 ]

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -134,6 +134,43 @@ class TestAWSLogs(unittest.TestCase):
         client.get_paginator.side_effect = paginator
         client.filter_log_events.side_effect = logs
 
+    def set_json_logs(self, botoclient):
+        client = Mock()
+        botoclient.return_value = client
+
+        event_keys = ["eventId", "timestamp", "ingestionTime",
+                      "message", "logStreamName"]
+        logs = [
+            {'events': mapkeys(event_keys,
+                               [[1, 0, 5000, '{"foo": "bar"}', "DDD"],
+                                [2, 0, 5000, '{"foo": {"bar": "baz"}}', "EEE"],
+                                [3, 0, 5006, "Hello 3", "DDD"]]),
+             'nextToken': 'token'},
+            {'events': []}
+        ]
+
+        groups = [
+            {'logGroups': [{'logGroupName': 'AAA'},
+                           {'logGroupName': 'BBB'},
+                           {'logGroupName': 'CCC'}]},
+        ]
+
+        streams = [
+            {'logStreams': [self._stream('DDD'),
+                            self._stream('EEE')]}
+        ]
+
+        def paginator(value):
+            mock = Mock()
+            mock.paginate.return_value = {
+                'describe_log_groups': groups,
+                'describe_log_streams': streams
+            }.get(value)
+            return mock
+
+        client.get_paginator.side_effect = paginator
+        client.filter_log_events.side_effect = logs
+
     @patch('boto3.client')
     def test_get_groups(self, botoclient):
         client = Mock()
@@ -251,6 +288,19 @@ class TestAWSLogs(unittest.TestCase):
                     "\x1b[32mAAA\x1b[0m \x1b[36mEEE\x1b[0m Hello 4\n"
                     "\x1b[32mAAA\x1b[0m \x1b[36mDDD\x1b[0m Hello 5\n"
                     "\x1b[32mAAA\x1b[0m \x1b[36mEEE\x1b[0m Hello 6\n"
+                    )
+
+        assert output == expected
+
+    @patch('boto3.client')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_main_get_query(self, mock_stdout, botoclient):
+        self.set_json_logs(botoclient)
+        main("awslogs get AAA DDD --query foo".split())
+        output = mock_stdout.getvalue()
+        expected = ("\x1b[32mAAA\x1b[0m \x1b[36mDDD\x1b[0m bar\n"
+                    "\x1b[32mAAA\x1b[0m \x1b[36mEEE\x1b[0m {\"bar\": \"baz\"}\n"
+                    "\x1b[32mAAA\x1b[0m \x1b[36mDDD\x1b[0m Hello 3\n"
                     )
 
         assert output == expected


### PR DESCRIPTION
We are using the excellent [journald-cloudwatch-logs](https://github.com/saymedia/journald- cloudwatch-logs) to ship out syslogs to cloudwatch. Each syslog entry arrives as a structured JSON object. This means filters are much more powerful and there is much more information. It also means that regular tailing is much noisier:

```
$ awslogs get journal
```

<img width="1273" alt="screenshot 2016-08-30 14 27 35" src="https://cloud.githubusercontent.com/assets/14028/18076100/40f637f4-6ebe-11e6-98cb-5335b5c0a7c3.png">

A simple solution seems to be to follow the conventions of awscli and [add JMESPath queries to the output](http://docs.aws.amazon.com/cli/latest/userguide/controlling-output.html#controlling-output-filter). All the required gear is already integrated into botocore. This patch introduces a `--query` arg which can be supplied to print only a selected portion of a JSON message:

```
$ awslogs get journal --query message
```
<img width="1276" alt="screenshot 2016-08-30 14 31 55" src="https://cloud.githubusercontent.com/assets/14028/18076153/b52ce79e-6ebe-11e6-939c-ab11e077277c.png">

Much better!