### PR TITLE
Filter groups by prefix when calling awslogs groups

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -139,6 +139,12 @@ def main(argv=None):
     groups_parser.set_defaults(func="list_groups")
     add_common_arguments(groups_parser)
 
+    groups_parser.add_argument("-p",
+                            "--log-group-prefix",
+                            action="store",
+                            dest="log_group_prefix",
+                            help="List only groups matching the prefix")
+
     # streams
     streams_parser = subparsers.add_parser('streams', description='List streams')
     streams_parser.set_defaults(func="list_streams")

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -140,10 +140,10 @@ def main(argv=None):
     add_common_arguments(groups_parser)
 
     groups_parser.add_argument("-p",
-                            "--log-group-prefix",
-                            action="store",
-                            dest="log_group_prefix",
-                            help="List only groups matching the prefix")
+                               "--log-group-prefix",
+                               action="store",
+                               dest="log_group_prefix",
+                               help="List only groups matching the prefix")
 
     # streams
     streams_parser = subparsers.add_parser('streams', description='List streams')

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -52,7 +52,7 @@ class AWSLogs(object):
         self.query = kwargs.get('query')
         if self.query is not None:
             self.query_expression = jmespath.compile(self.query)
-
+        self.log_group_prefix = kwargs.get('log_group_prefix')
         self.client = boto3.client(
             'logs',
             aws_access_key_id=self.aws_access_key_id,
@@ -201,8 +201,11 @@ class AWSLogs(object):
 
     def get_groups(self):
         """Returns available CloudWatch logs groups"""
+        kwargs = {}
+        if self.log_group_prefix is not None:
+            kwargs = {'logGroupNamePrefix': self.log_group_prefix}
         paginator = self.client.get_paginator('describe_log_groups')
-        for page in paginator.paginate():
+        for page in paginator.paginate(**kwargs):
             for group in page.get('logGroups', []):
                 yield group['logGroupName']
 

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -195,6 +195,18 @@ class TestAWSLogs(unittest.TestCase):
                          ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
 
     @patch('boto3.client')
+    def test_get_groups_with_log_group_prefix(self, botoclient):
+        client = Mock()
+        botoclient.return_value = client
+        client.get_paginator.return_value.paginate.return_value = [
+            {'logGroups': [{'logGroupName': 'A'}]}
+        ]
+
+        awslogs = AWSLogs(log_group_prefix='log_group_prefix')
+        self.assertEqual([g for g in awslogs.get_groups()],
+                         ['A'])
+
+    @patch('boto3.client')
     def test_get_streams(self, botoclient):
         client = Mock()
         botoclient.return_value = client


### PR DESCRIPTION
Added a new parameter to awslogs groups:

awslogs groups -p /aws
awslogs groups --log-group-prefix API
