### PR TITLE
Add support for caching temporary session credentials

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -7,6 +7,7 @@ from collections import deque
 
 import boto3
 from botocore.compat import json, six, total_seconds
+from .utils import JSONFileCache
 
 import jmespath
 
@@ -53,7 +54,11 @@ class AWSLogs(object):
         if self.query is not None:
             self.query_expression = jmespath.compile(self.query)
         self.log_group_prefix = kwargs.get('log_group_prefix')
-        self.client = boto3.client(
+        session = boto3.session.Session()
+        cred_chain = session._session.get_component('credential_provider')
+        provider = cred_chain.get_provider('assume-role')
+        provider.cache = JSONFileCache()
+        self.client = session.client(
             'logs',
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime, timedelta
 from collections import deque
 
+import botocore.session
 import boto3
 from botocore.compat import json, six, total_seconds
 from .utils import JSONFileCache
@@ -54,11 +55,11 @@ class AWSLogs(object):
         if self.query is not None:
             self.query_expression = jmespath.compile(self.query)
         self.log_group_prefix = kwargs.get('log_group_prefix')
-        session = boto3.session.Session()
-        cred_chain = session._session.get_component('credential_provider')
+        session = botocore.session.get_session()
+        cred_chain = session.get_component('credential_provider')
         provider = cred_chain.get_provider('assume-role')
         provider.cache = JSONFileCache()
-        self.client = session.client(
+        self.client = boto3.session.Session(botocore_session=session).client(
             'logs',
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -59,7 +59,7 @@ class AWSLogs(object):
         cred_chain = session.get_component('credential_provider')
         provider = cred_chain.get_provider('assume-role')
         provider.cache = JSONFileCache()
-        self.client = boto3.session.Session(botocore_session=session).client(
+        self.client = boto3.Session(botocore_session=session).client(
             'logs',
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,

--- a/awslogs/utils.py
+++ b/awslogs/utils.py
@@ -2,12 +2,14 @@ import datetime
 import json
 import os
 
+
 def json_encoder(obj):
     """JSON encoder that formats datetimes as ISO8601 format."""
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
     else:
         return obj
+
 
 class JSONFileCache(object):
     """JSON file cache.

--- a/awslogs/utils.py
+++ b/awslogs/utils.py
@@ -1,0 +1,54 @@
+import datetime
+import json
+import os
+
+def json_encoder(obj):
+    """JSON encoder that formats datetimes as ISO8601 format."""
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    else:
+        return obj
+
+class JSONFileCache(object):
+    """JSON file cache.
+    This provides a dict like interface that stores JSON serializable
+    objects.
+    The objects are serialized to JSON and stored in a file.  These
+    values can be retrieved at a later time.
+    """
+
+    CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
+
+    def __init__(self, working_dir=CACHE_DIR):
+        self._working_dir = working_dir
+
+    def __contains__(self, cache_key):
+        actual_key = self._convert_cache_key(cache_key)
+        return os.path.isfile(actual_key)
+
+    def __getitem__(self, cache_key):
+        """Retrieve value from a cache key."""
+        actual_key = self._convert_cache_key(cache_key)
+        try:
+            with open(actual_key) as f:
+                return json.load(f)
+        except (OSError, ValueError, IOError):
+            raise KeyError(cache_key)
+
+    def __setitem__(self, cache_key, value):
+        full_key = self._convert_cache_key(cache_key)
+        try:
+            file_content = json.dumps(value, default=json_encoder)
+        except (TypeError, ValueError):
+            raise ValueError("Value cannot be cached, must be "
+                             "JSON serializable: %s" % value)
+        if not os.path.isdir(self._working_dir):
+            os.makedirs(self._working_dir)
+        with os.fdopen(os.open(full_key,
+                               os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
+            f.truncate()
+            f.write(file_content)
+
+    def _convert_cache_key(self, cache_key):
+        full_path = os.path.join(self._working_dir, cache_key + '.json')
+        return full_path

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -65,13 +65,14 @@ class TestAWSLogsSessionCache(fake_filesystem_unittest.TestCase):
         key = 'some-random-key'
         with self.assertRaises(KeyError) as context:
             cache[key]
-        self.assertTrue(key in context.exception)
+        self.assertTrue(key in str(context.exception))
     
     def test_cache_non_serializable(self):
         cache = JSONFileCache()
         key = 'some-bad-key'
         with self.assertRaises(ValueError) as context:
             cache[key] = set()
+        self.assertTrue('Value cannot be cached, must be JSON serializable' in str(context.exception))
         
 
 class TestAWSLogsDatetimeParse(unittest.TestCase):

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -39,39 +39,37 @@ class TestAWSLogsSessionCache(fake_filesystem_unittest.TestCase):
     def setUp(self):
         self.setUpPyfakefs()
         self.cache_path = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
+        self.cache = JSONFileCache()
 
     def tearDown(self):
         pass
 
     def test_cache_lookup(self):
-        cache = JSONFileCache()
         key = 'my-profile--arn_aws_iam__111111111111_role-admin'
         data = {'test': 'test'}
         os.makedirs(self.cache_path)
         with open(self.cache_path + '/' + key + '.json', 'w') as f:
             json.dump(data, f)
-        self.assertEqual(cache[key], data)
+        self.assertEqual(self.cache[key], data)
+        self.assertTrue(key in self.cache)
 
     def test_cache_write(self):
-        cache = JSONFileCache()
         key = 'my-profile--arn_aws_iam__222222222222_role-admin'
-        data = {'test': 'test'}
-        cache[key] = data
+        data = {'test': 'test','date':datetime(2016, 3, 8, 11, 37, 24)}
+        self.cache[key] = data
         with open(self.cache_path + '/' + key + '.json') as d:
-            self.assertEqual(json.load(d), data)
+            self.assertEqual(json.load(d), {'test':'test','date':'2016-03-08T11:37:24'})
 
     def test_cache_miss(self):
-        cache = JSONFileCache()
         key = 'some-random-key'
         with self.assertRaises(KeyError) as context:
-            cache[key]
+            self.cache[key]
         self.assertTrue(key in str(context.exception))
     
     def test_cache_non_serializable(self):
-        cache = JSONFileCache()
         key = 'some-bad-key'
         with self.assertRaises(ValueError) as context:
-            cache[key] = set()
+            self.cache[key] = set()
         self.assertTrue('Value cannot be cached, must be JSON serializable' in str(context.exception))
         
 

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -30,7 +30,7 @@ def mapkeys(keys, rec_lst):
 
 
 class TestAWSLogsDatetimeParse(unittest.TestCase):
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('awslogs.core.datetime')
     def test_parse_datetime(self, datetime_mock, botoclient):
 
@@ -174,7 +174,7 @@ class TestAWSLogs(unittest.TestCase):
         client.get_paginator.side_effect = paginator
         client.filter_log_events.side_effect = logs
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     def test_get_groups(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -194,7 +194,7 @@ class TestAWSLogs(unittest.TestCase):
         self.assertEqual([g for g in awslogs.get_groups()],
                          ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     def test_get_groups_with_log_group_prefix(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -206,7 +206,7 @@ class TestAWSLogs(unittest.TestCase):
         self.assertEqual([g for g in awslogs.get_groups()],
                          ['A'])
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     def test_get_streams(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -226,7 +226,7 @@ class TestAWSLogs(unittest.TestCase):
         self.assertEqual([g for g in awslogs.get_streams()],
                          ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('awslogs.core.AWSLogs.parse_datetime')
     def test_get_streams_filtered_by_date(self, parse_datetime, botoclient):
         client = Mock()
@@ -242,7 +242,7 @@ class TestAWSLogs(unittest.TestCase):
         awslogs = AWSLogs(log_group_name='group', start='5', end='7')
         self.assertEqual([g for g in awslogs.get_streams()], ['B', 'C'])
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     def test_get_streams_from_pattern(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -276,7 +276,7 @@ class TestAWSLogs(unittest.TestCase):
         actual = [s for s in awslogs._get_streams_from_pattern('X', 'A[AC]A')]
         self.assertEqual(actual, expected)
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -291,7 +291,7 @@ class TestAWSLogs(unittest.TestCase):
                     )
         assert output == expected
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get_with_color(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -307,7 +307,7 @@ class TestAWSLogs(unittest.TestCase):
 
         assert output == expected
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get_query(self, mock_stdout, botoclient):
         self.set_json_logs(botoclient)
@@ -320,7 +320,7 @@ class TestAWSLogs(unittest.TestCase):
 
         assert output == expected
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -336,7 +336,7 @@ class TestAWSLogs(unittest.TestCase):
              "EEE Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nostream(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -352,7 +352,7 @@ class TestAWSLogs(unittest.TestCase):
              "AAA Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup_nostream(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -368,7 +368,7 @@ class TestAWSLogs(unittest.TestCase):
              "Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup_nostream_short_forms(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -384,7 +384,7 @@ class TestAWSLogs(unittest.TestCase):
              "Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_timestamp(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -402,7 +402,7 @@ class TestAWSLogs(unittest.TestCase):
              "1970-01-01T00:00:00.000Z Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_ingestion_time(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -420,7 +420,7 @@ class TestAWSLogs(unittest.TestCase):
              "1970-01-01T00:00:05.009Z Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_timestamp_and_ingestion_time(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -438,7 +438,7 @@ class TestAWSLogs(unittest.TestCase):
              "1970-01-01T00:00:00.000Z 1970-01-01T00:00:05.009Z Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get_deduplication(self, mock_stdout, botoclient):
         client = Mock()
@@ -490,7 +490,7 @@ class TestAWSLogs(unittest.TestCase):
              "AAA DDD Hello 3\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stderr', new_callable=StringIO)
     def test_main_get_no_matching_streams(self, mock_stderr, botoclient):
         client = Mock()
@@ -522,7 +522,7 @@ class TestAWSLogs(unittest.TestCase):
                          colored("No streams match your pattern 'foo.*'.\n",
                                  "red"))
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_groups(self, mock_stdout, botoclient):
         client = Mock()
@@ -544,7 +544,7 @@ class TestAWSLogs(unittest.TestCase):
              "CCC\n")
         )
 
-    @patch('boto3.client')
+    @patch('boto3.Session.client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_streams(self, mock_stdout, botoclient):
         client = Mock()

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -2,7 +2,6 @@ import os
 import sys
 import unittest
 import json
-from pyfakefs import fake_filesystem
 from pyfakefs import fake_filesystem_unittest
 
 from datetime import datetime

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     mock>=1.0.0; python_version<='3.3'
     coverage
     pytest
+    pyfakefs
 
 [testenv:lint]
 commands = flake8 awslogs


### PR DESCRIPTION
This PR adds support for caching temporary session credentials, using the same mechanism as used in the AWS CLI.

The main benefit of this feature is a much improved experience for users that require MFA for API access.  Prior to this PR, the experience is that users have to re-enter MFA token each time they run the command:

```
$ awslogs groups
Enter MFA code: ******
/my/log/group

$ awslogs get /my/log/group
Enter MFA code: ******
...
...
```

With this PR, the user experience will be that they only need to enter an MFA code once for the lifetime of the session credentials (e.g. once per hour):

```
$ awslogs groups
Enter MFA code: ******
/my/log/group

$ awslogs get /my/log/group
...
...
```

Caching is invoked only if the `assume-role` provider is active, which happens when you are using a profile that assumes a role:

```
$ export AWS_PROFILE=some-account-admin
$ cat ~/.aws/config
[profile some-account-admin]
source_profile=users-account
role_arn=arn:aws:iam::012345678912:role/admin
mfa_serial=arn:aws:iam::219876543210:mfa/justin.menga
region=us-west-2
```



