### PR TITLE
Gracefully exit on SIGPIPE

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -2,6 +2,7 @@ import re
 import sys
 import os
 import time
+import errno
 from datetime import datetime, timedelta
 from collections import deque
 
@@ -182,7 +183,15 @@ class AWSLogs(object):
                 output.append(message.rstrip())
 
                 print(' '.join(output))
-                sys.stdout.flush()
+                try:
+                    sys.stdout.flush()
+                except IOError as e:
+                    if e.errno == errno.EPIPE:
+                        # SIGPIPE received, so exit
+                        os._exit(0)
+                    else:
+                        # We don't want to handle any other errors from this
+                        raise
         try:
             consumer()
         except KeyboardInterrupt:


### PR DESCRIPTION
Piping to utilities that close out their pipe by design (such as `head`) causes a traceback message when the pipe is closed. This tweak catches that particular error condition and exits, and lets other IO failures continue to escalate.

Before:
```
(venv) $ ./command_line.py get log_group_sanitized ALL | head
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:24:55 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:24:56 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:24:58 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:25:00 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:01 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:04 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:05 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:25:05 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:25:08 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:10 UTC 2017)

================================================================================
You've found a bug! Please, raise an issue attaching the following traceback
https://github.com/jorgebastida/awslogs/issues/new
--------------------------------------------------------------------------------
Version: 0.9.0
Python: 2.7.5 (default, Sep 15 2016, 22:37:39)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
boto3 version: 1.4.4
Platform: Linux-3.10.0-327.10.1.el7.x86_64-x86_64-with-centos-7.2.1511-Core
Config: {'output_timestamp_enabled': False, 'output_group_enabled': True, 'end': None, 'aws_secret_access_key': 'SENSITIVE', 'log_stream_name': 'ALL', 'watch': False, 'aws_region': None, 'aws_session_token': 'SENSITIVE', 'start': '5m', 'aws_profile': 'SENSITIVE', 'filter_pattern': None, 'log_group_name': 'log_group_sanitized', 'output_ingestion_time_enabled': False, 'query': None, 'func': 'list_logs', 'aws_access_key_id': 'SENSITIVE', 'color_enabled': True, 'output_stream_enabled': True}
Args: ['./command_line.py', 'get', 'log_group_sanitized', 'ALL']

Traceback (most recent call last):
  File "/homedir_sanitized/src/awslogs/awslogs/bin.py", line 172, in main
    getattr(logs, options.func)()
  File "/homedir_sanitized/src/awslogs/awslogs/core.py", line 187, in list_logs
    consumer()
  File "/homedir_sanitized/src/awslogs/awslogs/core.py", line 185, in consumer
    sys.stdout.flush()
IOError: [Errno 32] Broken pipe
================================================================================
```



After:
```
(venv) $ ./command_line.py get log_group_sanitized ALL | head
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:33 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:25:33 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:35 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:25:35 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:36 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:40 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:25:40 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:41 UTC 2017)
log_group_sanitized log_stream_sanitized1 Test log message from 127509dae97b (Wed Apr 12 23:25:45 UTC 2017)
log_group_sanitized log_stream_sanitized2 Test log message from 4edd0756f357 (Wed Apr 12 23:25:45 UTC 2017)
(venv) $
```