### PR TITLE
Allow floating point, negative, and second unit times for start param…

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -248,13 +248,16 @@ class AWSLogs(object):
         if not datetime_text:
             return None
 
-        ago_regexp = r'(\d+)\s?(m|minute|minutes|h|hour|hours|d|day|days|w|weeks|weeks)(?: ago)?'
+        ago_regexp = r'([+-]?([0-9]*[.])?[0-9]+)\s?(s|sec|secs|second|seconds|m|minute|minutes|h|hour|hours|d|day|days|w|weeks|weeks)(?: ago)?'
         ago_match = re.match(ago_regexp, datetime_text)
 
         if ago_match:
-            amount, unit = ago_match.groups()
-            amount = int(amount)
-            unit = {'m': 60, 'h': 3600, 'd': 86400, 'w': 604800}[unit[0]]
+            amount, whole_part, unit = ago_match.groups()
+            try:
+                amount = int(amount)
+            except:
+                amount = float(amount)
+            unit = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400, 'w': 604800}[unit[0]]
             date = datetime.utcnow() + timedelta(seconds=unit * amount * -1)
         else:
             try:


### PR DESCRIPTION
This change allows the the --start parameter to take on:

values starting with + or -
floating point values with . in them
values denominated in seconds

like:

'-1 min ago' (1 minute in the future)
'2.5 weeks ago'
'+.125 s' (1/8th of a second ago)

It does not allow numbers with a terminal . like:  123. 

