### PR TITLE
Don't use exhausted nextToken

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -131,6 +131,8 @@ class AWSLogs(object):
                 if 'nextToken' in response:
                     kwargs['nextToken'] = response['nextToken']
                 else:
+                    # No more results for this token, don't try to use it again
+                    kwargs.pop('nextToken', None)
                     yield do_wait
 
         def consumer():


### PR DESCRIPTION
It seems the AWS API changed so that if you specify a nextToken that you've already used, you don't actually get new results (and a new nextToken).

This patch simply drops the nextToken from the request after it's been used (which appears to fix the `--watch` behaviour at least for me).

While I haven't completely read the existing bugs and pull requests for this, this seems like a relatively minor tweak to make the watch behaviour work again. (related are #74 and #62)