### PR TITLE
Credential cache for MFA sessions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Thomas Grainger <website@graingert.co.uk>
 Charlie Chrisman <charlie@plivo.com>
 Samuel Cochran <sj26@sj26.com>
 rwolfson <rwolfson>
+Juhani Hietikko <juhani.hietikko@gmail.com>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 ======
 - Add finer-grained control over color output (Thanks Alex Pinkney)
 - Make watch interval configurable (Thanks Logan Hendricks)
+- Reuse aws-cli MFA sessions cache if present (Thanks Juhani Hietikko)
 
 0.10.0
 =======

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -158,12 +158,6 @@ def main(argv=None):
     # Parse input
     options, args = parser.parse_known_args(argv)
 
-    # Workaround the fact that boto3 don't allow you to specify a profile
-    # when you instantiate the a client. We need --profile because that's
-    # the api people are use to with aws-cli.
-    if getattr(options, 'aws_profile', None):
-        os.environ['AWS_PROFILE'] = options.aws_profile
-
     try:
         logs = AWSLogs(**vars(options))
         if not hasattr(options, 'func'):

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -56,6 +56,7 @@ class AWSLogs(object):
         self.aws_access_key_id = kwargs.get('aws_access_key_id')
         self.aws_secret_access_key = kwargs.get('aws_secret_access_key')
         self.aws_session_token = kwargs.get('aws_session_token')
+        self.aws_profile = kwargs.get('aws_profile')
         self.log_group_name = kwargs.get('log_group_name')
         self.log_stream_name = kwargs.get('log_stream_name')
         self.filter_pattern = kwargs.get('filter_pattern')
@@ -73,7 +74,7 @@ class AWSLogs(object):
             self.query_expression = jmespath.compile(self.query)
         self.log_group_prefix = kwargs.get('log_group_prefix')
         self.client = boto3_client(
-            kwargs.get('aws_profile'),
+            self.aws_profile,
             self.aws_access_key_id,
             self.aws_secret_access_key,
             self.aws_session_token,

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -27,6 +27,11 @@ def milis2iso(milis):
 def boto3_client(aws_profile, aws_access_key_id, aws_secret_access_key, aws_session_token, aws_region):
     core_session = botocore.session.get_session()
     core_session.set_config_variable('profile', aws_profile)
+
+    credential_provider = core_session.get_component('credential_provider').get_provider('assume-role')
+    cache_dir = os.path.join(os.path.expanduser('~'), '.aws', 'cli', 'cache')
+    credential_provider.cache = botocore.credentials.JSONFileCache(cache_dir)
+
     session = boto3.session.Session(botocore_session=core_session)
     return session.client(
         'logs',

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -604,3 +604,13 @@ class TestAWSLogs(unittest.TestCase):
     @patch('sys.stderr', new_callable=StringIO)
     def test_version(self, mock_stderr):
         self.assertRaises(SystemExit, main, "awslogs --version".split())
+
+    @patch('botocore.session.get_session')
+    def test_boto3_client_creation(self, mock_core_session):
+        client = Mock()
+        boto_session = Mock()
+        mock_core_session.return_value = boto_session
+        boto_session.create_client.return_value = client
+
+        awslogs = AWSLogs()
+        self.assertEqual(client, awslogs.client)

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -30,7 +30,7 @@ def mapkeys(keys, rec_lst):
 
 
 class TestAWSLogsDatetimeParse(unittest.TestCase):
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('awslogs.core.datetime')
     def test_parse_datetime(self, datetime_mock, botoclient):
 
@@ -174,7 +174,7 @@ class TestAWSLogs(unittest.TestCase):
         client.get_paginator.side_effect = paginator
         client.filter_log_events.side_effect = logs
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     def test_get_groups(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -194,7 +194,7 @@ class TestAWSLogs(unittest.TestCase):
         self.assertEqual([g for g in awslogs.get_groups()],
                          ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     def test_get_groups_with_log_group_prefix(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -206,7 +206,7 @@ class TestAWSLogs(unittest.TestCase):
         self.assertEqual([g for g in awslogs.get_groups()],
                          ['A'])
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     def test_get_streams(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -226,7 +226,7 @@ class TestAWSLogs(unittest.TestCase):
         self.assertEqual([g for g in awslogs.get_streams()],
                          ['A', 'B', 'C', 'D', 'E', 'F', 'G'])
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('awslogs.core.AWSLogs.parse_datetime')
     def test_get_streams_filtered_by_date(self, parse_datetime, botoclient):
         client = Mock()
@@ -242,7 +242,7 @@ class TestAWSLogs(unittest.TestCase):
         awslogs = AWSLogs(log_group_name='group', start='5', end='7')
         self.assertEqual([g for g in awslogs.get_streams()], ['B', 'C'])
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     def test_get_streams_from_pattern(self, botoclient):
         client = Mock()
         botoclient.return_value = client
@@ -276,7 +276,7 @@ class TestAWSLogs(unittest.TestCase):
         actual = [s for s in awslogs._get_streams_from_pattern('X', 'A[AC]A')]
         self.assertEqual(actual, expected)
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -291,7 +291,7 @@ class TestAWSLogs(unittest.TestCase):
                     )
         assert output == expected
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get_with_color(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -307,7 +307,7 @@ class TestAWSLogs(unittest.TestCase):
 
         assert output == expected
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get_query(self, mock_stdout, botoclient):
         self.set_json_logs(botoclient)
@@ -320,7 +320,7 @@ class TestAWSLogs(unittest.TestCase):
 
         assert output == expected
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -336,7 +336,7 @@ class TestAWSLogs(unittest.TestCase):
              "EEE Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nostream(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -352,7 +352,7 @@ class TestAWSLogs(unittest.TestCase):
              "AAA Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup_nostream(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -368,7 +368,7 @@ class TestAWSLogs(unittest.TestCase):
              "Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup_nostream_short_forms(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -384,7 +384,7 @@ class TestAWSLogs(unittest.TestCase):
              "Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_timestamp(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -402,7 +402,7 @@ class TestAWSLogs(unittest.TestCase):
              "1970-01-01T00:00:00.000Z Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_ingestion_time(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -420,7 +420,7 @@ class TestAWSLogs(unittest.TestCase):
              "1970-01-01T00:00:05.009Z Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_timestamp_and_ingestion_time(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
@@ -438,7 +438,7 @@ class TestAWSLogs(unittest.TestCase):
              "1970-01-01T00:00:00.000Z 1970-01-01T00:00:05.009Z Hello 6\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get_deduplication(self, mock_stdout, botoclient):
         client = Mock()
@@ -490,7 +490,7 @@ class TestAWSLogs(unittest.TestCase):
              "AAA DDD Hello 3\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stderr', new_callable=StringIO)
     def test_main_get_no_matching_streams(self, mock_stderr, botoclient):
         client = Mock()
@@ -523,7 +523,7 @@ class TestAWSLogs(unittest.TestCase):
                                  "for the given time period.\n",
                                  "red"))
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_groups(self, mock_stdout, botoclient):
         client = Mock()
@@ -545,7 +545,7 @@ class TestAWSLogs(unittest.TestCase):
              "CCC\n")
         )
 
-    @patch('boto3.client')
+    @patch('awslogs.core.boto3_client')
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_streams(self, mock_stdout, botoclient):
         client = Mock()


### PR DESCRIPTION
Fix for https://github.com/jorgebastida/awslogs/issues/202

The boto3.client is created so that it's configured to use a common credential cache with AWS CLI. When assuming a role with MFA as described in the issue, the MFA code is automatically prompted, and the MFA session is stored in the credential cache. When the session has expired, MFA code is again prompted to renew it.

This also removes the need for the workaround where the `--profile` option was set to an environment variable. This is because profile is now configured to the botocore.session which is used to create the boto3.client.

I've done some cursory testing (on MacOS High Sierra) to check that awslogs still works with a profile that doesn't assume role with MFA, i.e. the credential cache doesn't have any effect when it's not needed. Another case that I've quickly tested is when `--profile` is not given, but instead the AWS access key is specified in environment variables.