### PR TITLE
added watch interval.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Charlie Chrisman <charlie@plivo.com>
 Samuel Cochran <sj26@sj26.com>
 rwolfson <@rwolfson>
 Alex Pinkney <@apinkney97>
+Logan Hendricks <@loghen41>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.11.0
 ======
 - Add finer-grained control over color output (Thanks Alex Pinkney)
+- Make watch interval configurable (Thanks Logan Hendricks)
 
 0.10.0
 =======

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -104,7 +104,7 @@ def main(argv=None):
                             dest='interval',
                             type=int,
                             default=1,
-                            help="Interval at which to query for new log lines")
+                            help="Interval in seconds at which to query for new log lines")
 
     get_parser.add_argument("-G",
                             "--no-group",

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -99,6 +99,13 @@ def main(argv=None):
                             dest='watch',
                             help="Query for new log lines constantly")
 
+    get_parser.add_argument("-i",
+                            "--interval",
+                            dest='interval',
+                            type=int,
+                            default=1,
+                            help="Interval at which to query for new log lines")
+
     get_parser.add_argument("-G",
                             "--no-group",
                             action='store_false',

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -100,8 +100,8 @@ def main(argv=None):
                             help="Query for new log lines constantly")
 
     get_parser.add_argument("-i",
-                            "--interval",
-                            dest='interval',
+                            "--watch-interval",
+                            dest='watch_interval',
                             type=int,
                             default=1,
                             help="Interval in seconds at which to query for new log lines")

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -42,7 +42,7 @@ class AWSLogs(object):
         self.log_stream_name = kwargs.get('log_stream_name')
         self.filter_pattern = kwargs.get('filter_pattern')
         self.watch = kwargs.get('watch')
-        self.interval = kwargs.get('interval')
+        self.watch_interval = kwargs.get('watch_interval')
         self.color_enabled = kwargs.get('color_enabled')
         self.output_stream_enabled = kwargs.get('output_stream_enabled')
         self.output_group_enabled = kwargs.get('output_group_enabled')
@@ -139,7 +139,7 @@ class AWSLogs(object):
 
                 if event is do_wait:
                     if self.watch:
-                        time.sleep(self.interval)
+                        time.sleep(self.watch_interval)
                         continue
                     else:
                         return

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -42,6 +42,7 @@ class AWSLogs(object):
         self.log_stream_name = kwargs.get('log_stream_name')
         self.filter_pattern = kwargs.get('filter_pattern')
         self.watch = kwargs.get('watch')
+        self.interval = kwargs.get('interval')
         self.color_enabled = kwargs.get('color_enabled')
         self.output_stream_enabled = kwargs.get('output_stream_enabled')
         self.output_group_enabled = kwargs.get('output_group_enabled')
@@ -138,7 +139,7 @@ class AWSLogs(object):
 
                 if event is do_wait:
                     if self.watch:
-                        time.sleep(1)
+                        time.sleep(self.interval)
                         continue
                     else:
                         return


### PR DESCRIPTION
AWS Cloudwatch limits are only 5 queries / second.  As such, the current amount of threads that can be run at a single time is 5. 

Exposed a public variable named interval, to allow the user to change the interval at which awslogs queries Cloudwatch.  