### PR TITLE
Add finer-grained control over color output (similar to ls, grep etc)

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -123,10 +123,15 @@ def main(argv=None):
 
     add_date_range_arguments(get_parser)
 
-    get_parser.add_argument("--no-color",
-                            action='store_false',
-                            dest='color_enabled',
-                            help="Do not color output")
+    get_parser.add_argument("--color",
+                            choices=['never', 'always', 'auto'],
+                            metavar='WHEN',
+                            default='auto',
+                            help=("When to color output. WHEN can be 'auto' "
+                                  "(default if ommitted), 'never', or "
+                                  "'always'. With --color=auto, output is "
+                                  "colored only when standard output is "
+                                  "connected to a terminal."))
 
     get_parser.add_argument("-q",
                             "--query",

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -18,6 +18,13 @@ from dateutil.tz import tzutc
 from . import exceptions
 
 
+COLOR_ENABLED = {
+    'always': True,
+    'never': False,
+    'auto': sys.stdout.isatty(),
+}
+
+
 def milis2iso(milis):
     res = datetime.utcfromtimestamp(milis/1000.0).isoformat()
     return (res + ".000")[:23] + 'Z'
@@ -42,7 +49,7 @@ class AWSLogs(object):
         self.log_stream_name = kwargs.get('log_stream_name')
         self.filter_pattern = kwargs.get('filter_pattern')
         self.watch = kwargs.get('watch')
-        self.color_enabled = kwargs.get('color_enabled')
+        self.color_enabled = COLOR_ENABLED.get(kwargs.get('color'), True)
         self.output_stream_enabled = kwargs.get('output_stream_enabled')
         self.output_group_enabled = kwargs.get('output_group_enabled')
         self.output_timestamp_enabled = kwargs.get('output_timestamp_enabled')

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -280,7 +280,7 @@ class TestAWSLogs(unittest.TestCase):
     @patch('sys.stdout', new_callable=StringIO)
     def test_main_get(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
-        main("awslogs get AAA DDD --no-color".split())
+        main("awslogs get AAA DDD --color=never".split())
         output = mock_stdout.getvalue()
         expected = ("AAA DDD Hello 1\n"
                     "AAA EEE Hello 2\n"
@@ -324,7 +324,7 @@ class TestAWSLogs(unittest.TestCase):
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
-        main("awslogs get --no-group AAA DDD --no-color".split())
+        main("awslogs get --no-group AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),
@@ -340,7 +340,7 @@ class TestAWSLogs(unittest.TestCase):
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nostream(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
-        main("awslogs get --no-stream AAA DDD --no-color".split())
+        main("awslogs get --no-stream AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),
@@ -356,7 +356,7 @@ class TestAWSLogs(unittest.TestCase):
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup_nostream(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
-        main("awslogs get --no-group --no-stream AAA DDD --no-color".split())
+        main("awslogs get --no-group --no-stream AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),
@@ -372,7 +372,7 @@ class TestAWSLogs(unittest.TestCase):
     @patch('sys.stdout', new_callable=StringIO)
     def test_get_nogroup_nostream_short_forms(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
-        main("awslogs get -GS AAA DDD --no-color".split())
+        main("awslogs get -GS AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),
@@ -390,7 +390,7 @@ class TestAWSLogs(unittest.TestCase):
         self.set_ABCDE_logs(botoclient)
         main("awslogs get "
              "--timestamp --no-group --no-stream "
-             "AAA DDD --no-color".split())
+             "AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),
@@ -408,7 +408,7 @@ class TestAWSLogs(unittest.TestCase):
         self.set_ABCDE_logs(botoclient)
         main("awslogs get "
              "--ingestion-time --no-group --no-stream "
-             "AAA DDD --no-color".split())
+             "AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),
@@ -426,7 +426,7 @@ class TestAWSLogs(unittest.TestCase):
         self.set_ABCDE_logs(botoclient)
         main("awslogs get "
              "--timestamp --ingestion-time --no-group --no-stream "
-             "AAA DDD --no-color".split())
+             "AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),
@@ -481,7 +481,7 @@ class TestAWSLogs(unittest.TestCase):
 
         client.get_paginator.side_effect = paginator
         client.filter_log_events.side_effect = logs
-        main("awslogs get AAA DDD --no-color".split())
+        main("awslogs get AAA DDD --color=never".split())
 
         self.assertEqual(
             mock_stdout.getvalue(),


### PR DESCRIPTION
This addresses the underlying problem in #211.

This mimics the `--color` option of `ls` and `grep` (and probably other commands).

The default option (`--color=auto`) causes output to be coloured only when stdout is a terminal.

This means, for example, when piping the output of `awslogs` into `less` or redirecting to a file, the ANSI escape sequences aren't emitted and don't clutter up the output.

`--color=never` and `--color=always` force coloured output to be disabled and enabled respectively.