### PR TITLE
Support AWS_PROFILE environment variable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,5 +174,5 @@ How to provide AWS credentials to awslogs
 
 Although, the most straightforward thing to do might be use ``--aws-access-key-id`` and ``--aws-secret-access-key``, this will eventually become a pain in the ass.
 
-* If you only have one ``AWS`` account, my personal recommendation would be to configure `aws-cli <http://aws.amazon.com/cli/>`_. ``awslogs`` will use those credentials if available. If you have multiple ``AWS`` profiles managed by ``aws-cli``, just adds ``--profile [PROFILE_NAME]`` at the end of every ``awslogs`` command to use those credentials.
+* If you only have one ``AWS`` account, my personal recommendation would be to configure `aws-cli <http://aws.amazon.com/cli/>`_. ``awslogs`` will use those credentials if available. If you have multiple ``AWS`` profiles managed by ``aws-cli``, just add ``--profile [PROFILE_NAME]`` at the end of every ``awslogs`` command to use those credentials, or set the ``AWS_PROFILE`` env variable.
 * If you don't want to setup ``aws-cli``, I would recommend you to use `envdir <https://pypi.python.org/pypi/envdir>`_ in order to make ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` available to ``awslogs``.

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -46,7 +46,7 @@ def main(argv=None):
         parser.add_argument("--profile",
                             dest="aws_profile",
                             type=str,
-                            default=None,
+                            default=os.environ.get('AWS_PROFILE', None),
                             help="aws profile")
 
         parser.add_argument("--aws-region",

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -63,7 +63,7 @@ class AWSLogs(object):
         self.aws_access_key_id = kwargs.get('aws_access_key_id')
         self.aws_secret_access_key = kwargs.get('aws_secret_access_key')
         self.aws_session_token = kwargs.get('aws_session_token')
-        self.aws_profile = kwargs.get('aws_profile')
+        self.aws_profile = kwargs.get('aws_profile') or os.getenv('AWS_PROFILE')
         self.log_group_name = kwargs.get('log_group_name')
         self.log_stream_name = kwargs.get('log_stream_name')
         self.filter_pattern = kwargs.get('filter_pattern')

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -63,7 +63,7 @@ class AWSLogs(object):
         self.aws_access_key_id = kwargs.get('aws_access_key_id')
         self.aws_secret_access_key = kwargs.get('aws_secret_access_key')
         self.aws_session_token = kwargs.get('aws_session_token')
-        self.aws_profile = kwargs.get('aws_profile') or os.getenv('AWS_PROFILE')
+        self.aws_profile = kwargs.get('aws_profile')
         self.log_group_name = kwargs.get('log_group_name')
         self.log_stream_name = kwargs.get('log_stream_name')
         self.filter_pattern = kwargs.get('filter_pattern')


### PR DESCRIPTION
I frequently switch between profiles by using `export AWS_PROFILE=whatever`.  It would be convenient if awslogs supported this without having to specify `--profile` each time.  This would also probably be the expected behavior for someone who had set this environment variable.