### PR TITLE
Added the dependency botocore>=1.8.14 to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    'boto3>=1.2.1',
-    'botocore>=1.8.14',
+    'boto3>=1.5.0',
     'jmespath>=0.7.1,<1.0.0',
     'termcolor>=1.1.0',
     'python-dateutil>=2.4.0'

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'boto3>=1.2.1',
+    'botocore>=1.8.14',
     'jmespath>=0.7.1,<1.0.0',
     'termcolor>=1.1.0',
     'python-dateutil>=2.4.0'


### PR DESCRIPTION
- Added the dependency botocore>=1.8.14 to install_requires in setup.py
- This dependecy is required because the class 'botocore.credentials.JSONFileCache' (used by awslogs.core.AWSLogs) was added in version 1.8.14
- This commit fixes #234 