### PR TITLE
Gracefully fail when log messages are not valid json #246

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -203,8 +203,11 @@ class AWSLogs(object):
 
                 message = event['message']
                 if self.query is not None and message[0] == '{':
-                    parsed = json.loads(event['message'])
-                    message = self.query_expression.search(parsed)
+                    try:
+                        parsed = json.loads(event['message'])
+                        message = self.query_expression.search(parsed)
+                    except ValueError: #includes JSONDecodeError
+                        raise exceptions.JsonFormattingOrDecodingError()
                     if not isinstance(message, six.string_types):
                         message = json.dumps(message)
                 output.append(message.rstrip())

--- a/awslogs/exceptions.py
+++ b/awslogs/exceptions.py
@@ -25,9 +25,9 @@ class TooManyStreamsFilteredError(BaseAWSLogsException):
                 "pattern and filter the output of awslogs.").format(*self.args)
 
 
-class NoStreamsFilteredError(BaseAWSLogsException):
+class JsonFormattingOrDecodingError(BaseAWSLogsException):
 
-    code = 7
+    code = 8
 
     def hint(self):
-        return ("No streams match your pattern '{0}' for the given time period.").format(*self.args)
+        return ("Invalid JSON string or string could not be decoded")

--- a/awslogs/exceptions.py
+++ b/awslogs/exceptions.py
@@ -24,6 +24,13 @@ class TooManyStreamsFilteredError(BaseAWSLogsException):
                 "It might be helpful to you to not filter streams by any "
                 "pattern and filter the output of awslogs.").format(*self.args)
 
+class NoStreamsFilteredError(BaseAWSLogsException):
+
+    code = 7
+
+    def hint(self):
+        return ("No streams match your pattern '{0}' for the given time period.").format(*self.args)
+
 
 class JsonFormattingOrDecodingError(BaseAWSLogsException):
 


### PR DESCRIPTION
Added an exception class to be used during the parsing attempt of the JSON message while building the message output.
In case the JSON is not valid or contains characters that cannot be decoded, a graceful failure will occur.