### PR TITLE
Added aws_endpoint_url cli option

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -55,6 +55,12 @@ def main(argv=None):
                             default=os.environ.get('AWS_REGION', None),
                             help="aws region")
 
+        parser.add_argument("--aws-endpoint-url",
+                            dest="aws_endpoint_url",
+                            type=str,
+                            default=None,
+                            help="aws endpoint url")
+
     def add_date_range_arguments(parser, default_start='5m'):
         parser.add_argument("-s", "--start",
                             type=str,

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -31,7 +31,15 @@ def milis2iso(milis):
     return (res + ".000")[:23] + 'Z'
 
 
-def boto3_client(aws_profile, aws_access_key_id, aws_secret_access_key, aws_session_token, aws_region):
+def boto3_client(
+    aws_profile,
+    aws_access_key_id,
+    aws_secret_access_key,
+    aws_session_token,
+    aws_region,
+    aws_endpoint_url
+):
+
     core_session = botocore.session.get_session()
     core_session.set_config_variable('profile', aws_profile)
 
@@ -45,7 +53,8 @@ def boto3_client(aws_profile, aws_access_key_id, aws_secret_access_key, aws_sess
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_session_token=aws_session_token,
-        region_name=aws_region)
+        region_name=aws_region,
+        endpoint_url=aws_endpoint_url)
 
 
 class AWSLogs(object):
@@ -61,6 +70,7 @@ class AWSLogs(object):
     def __init__(self, **kwargs):
         self.aws_region = kwargs.get('aws_region')
         self.aws_access_key_id = kwargs.get('aws_access_key_id')
+        self.aws_endpoint_url = kwargs.get('aws_endpoint_url')
         self.aws_secret_access_key = kwargs.get('aws_secret_access_key')
         self.aws_session_token = kwargs.get('aws_session_token')
         self.aws_profile = kwargs.get('aws_profile')
@@ -86,7 +96,8 @@ class AWSLogs(object):
             self.aws_access_key_id,
             self.aws_secret_access_key,
             self.aws_session_token,
-            self.aws_region
+            self.aws_region,
+            self.aws_endpoint_url
         )
 
     def _get_streams_from_pattern(self, group, pattern):


### PR DESCRIPTION
To be able to use awslogs with locally running instances of cloudwatch such as [localstack](https://github.com/localstack/localstack), we need a way to overwrite the endpoint url.

This PR adds an `--aws-endpoint-url` cli flag to change the endpoint that is called by awslogs.