### PR TITLE
Try to use default boto methods for establishing a session

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -32,20 +32,18 @@ def milis2iso(milis):
 
 
 def boto3_client(aws_profile, aws_access_key_id, aws_secret_access_key, aws_session_token, aws_region):
-    core_session = botocore.session.get_session()
-    core_session.set_config_variable('profile', aws_profile)
+    if any(param is not None for param in [aws_access_key_id, aws_secret_access_key, aws_session_token, aws_region]):
+        core_session = botocore.session.get_session()
+    elif aws_profile is not None:
+        session = boto3.Session(profile_name=aws_profile)
+    else:
+        session = boto3.Session()
 
-    credential_provider = core_session.get_component('credential_provider').get_provider('assume-role')
+    credential_provider = session._session.get_component('credential_provider').get_provider('assume-role')
     cache_dir = os.path.join(os.path.expanduser('~'), '.aws', 'cli', 'cache')
     credential_provider.cache = botocore.credentials.JSONFileCache(cache_dir)
 
-    session = boto3.session.Session(botocore_session=core_session)
-    return session.client(
-        'logs',
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        aws_session_token=aws_session_token,
-        region_name=aws_region)
+    return session.client('logs')
 
 
 class AWSLogs(object):


### PR DESCRIPTION
Letting boto determine how to get your session is generally a good thing. This fixes the bugs around not pulling region info from your aws creds config for example.