### PR TITLE
Allow specifying relative times in seconds

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -275,13 +275,13 @@ class AWSLogs(object):
         if not datetime_text:
             return None
 
-        ago_regexp = r'(\d+)\s?(m|minute|minutes|h|hour|hours|d|day|days|w|weeks|weeks)(?: ago)?'
+        ago_regexp = r'(\d+)\s?(s|sec|second|m|minute|minutes|h|hour|hours|d|day|days|w|weeks|weeks)(?: ago)?'
         ago_match = re.match(ago_regexp, datetime_text)
 
         if ago_match:
             amount, unit = ago_match.groups()
             amount = int(amount)
-            unit = {'m': 60, 'h': 3600, 'd': 86400, 'w': 604800}[unit[0]]
+            unit = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400, 'w': 604800}[unit[0]]
             date = datetime.utcnow() + timedelta(seconds=unit * amount * -1)
         else:
             try:

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -44,7 +44,16 @@ class TestAWSLogsDatetimeParse(unittest.TestCase):
 
         self.assertEqual(awslogs.parse_datetime(''), None)
         self.assertEqual(awslogs.parse_datetime(None), None)
-        plan = (('2015-01-01 02:59:00', '1m'),
+        plan = (('2015-01-01 02:59:59', '1s'),
+                ('2015-01-01 02:59:59', '1s ago'),
+                ('2015-01-01 02:59:59', '1sec'),
+                ('2015-01-01 02:59:59', '1sec ago'),
+                ('2015-01-01 02:59:59', '1second'),
+                ('2015-01-01 02:59:59', '1second ago'),
+                ('2015-01-01 02:59:59', '1seconds'),
+                ('2015-01-01 02:59:59', '1seconds ago'),
+
+                ('2015-01-01 02:59:00', '1m'),
                 ('2015-01-01 02:59:00', '1m ago'),
                 ('2015-01-01 02:59:00', '1minute'),
                 ('2015-01-01 02:59:00', '1minute ago'),


### PR DESCRIPTION
Time values in seconds were not recognized as relative times in the
same way as minutes, hours, etc. This produced surprising results;
'30s' was passed directly to dateutil, which interpreted it as meaning
30 seconds into the current day, so awslogs displayed 15 hours of log
data rather than the expected 30 seconds of it.