### PR TITLE
Add localtime option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Features
 
   - ``--timestamp`` Prints the creation timestamp of each event.
   - ``--ingestion-time`` Prints the ingestion time of each event.
+  - ``--localtime`` (or ``-l``) Use local time instead of UTC time when printing timestamps.
 
 
 Example

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -123,6 +123,12 @@ def main(argv=None):
                             dest='output_timestamp_enabled',
                             help="Add creation timestamp to the output")
 
+    get_parser.add_argument("-l",
+                            "--localtime",
+                            action='store_true',
+                            dest='output_localtime_enabled',
+                            help="Use local time zone and format instead of UTC time in timestamps")
+
     get_parser.add_argument("--ingestion-time",
                             action='store_true',
                             dest='output_ingestion_time_enabled',

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -4,6 +4,8 @@ import os
 import time
 import errno
 from datetime import datetime, timedelta
+import locale
+import pytz
 from collections import deque
 
 import boto3
@@ -14,7 +16,7 @@ import jmespath
 
 from termcolor import colored
 from dateutil.parser import parse
-from dateutil.tz import tzutc
+from dateutil.tz import tzutc, tzlocal
 
 from . import exceptions
 
@@ -26,7 +28,13 @@ COLOR_ENABLED = {
 }
 
 
-def milis2iso(milis):
+def milis2iso(milis, localtime):
+    if localtime:
+        return (
+            pytz.utc.localize(datetime.utcfromtimestamp(milis/1000.0))
+            .astimezone(tzlocal())
+            .strftime("%x %X:%f")[:-3]
+        )
     res = datetime.utcfromtimestamp(milis/1000.0).isoformat()
     return (res + ".000")[:23] + 'Z'
 
@@ -73,6 +81,9 @@ class AWSLogs(object):
         self.output_stream_enabled = kwargs.get('output_stream_enabled')
         self.output_group_enabled = kwargs.get('output_group_enabled')
         self.output_timestamp_enabled = kwargs.get('output_timestamp_enabled')
+        self.output_localtime_enabled = kwargs.get('output_localtime_enabled')
+        if self.output_localtime_enabled:
+            locale.setlocale(locale.LC_TIME,'')
         self.output_ingestion_time_enabled = kwargs.get(
             'output_ingestion_time_enabled')
         self.start = self.parse_datetime(kwargs.get('start'))
@@ -189,14 +200,16 @@ class AWSLogs(object):
                 if self.output_timestamp_enabled:
                     output.append(
                         self.color(
-                            milis2iso(event['timestamp']),
+                            milis2iso(event['timestamp'],
+                                self.output_localtime_enabled),
                             'yellow'
                         )
                     )
                 if self.output_ingestion_time_enabled:
                     output.append(
                         self.color(
-                            milis2iso(event['ingestionTime']),
+                            milis2iso(event['ingestionTime'],
+                                self.output_localtime_enabled),
                             'blue'
                         )
                     )


### PR DESCRIPTION
Add `--localtime` (or `-l`) option to use local time zone and format instead of UTC time in timestamps.

Fixes https://github.com/jorgebastida/awslogs/issues/92
