### PR TITLE
Use the configure region if one is set and drop python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,13 @@ dist: xenial
 language: python
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV=py26
-      dist: trusty
-      sudo: false
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
       env: TOXENV=py37
     - python: 3.7
       env: TOXENV=lint

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ Unrelease
 =========
 
 - Use the configured region when using ``--profile``.
+- Drop support for dead Python versions.
+- Support Python 3.7 and 3.8.
 
 0.12.0
 ======

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Unrelease
+=========
+
+- Use the configured region when using ``--profile``.
+
 0.12.0
 ======
 - Extra polish on issue markdown (Thanks Oliver Bristow)

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -141,42 +141,42 @@ Run all tests under one python version using `tox`
 First, check, what python versions is `tox` configured to run for::
 
     $ tox -l
-    py26
-    py27
-    py33
-    py34
+    py35
+    py36
+    py37
+    py38
 
-Assuming you want to run tests for python 2.7, run::
+Assuming you want to run tests for python 3.8, run::
 
-    $ tox -e py27
+    $ tox -e py38
 
 Creating and recreating virtualenvs by `tox`
 --------------------------------------------
 
 Running `tox`, one or more virtualenvs are always created::
 
-    $ tox -e py27
+    $ tox -e py38
 
 Virtualenvs are by default located in `.tox` directory::
 
     $ dir .tox
     dist
     log
-    py27
+    py38
 
-.. note:: Ignore the `dist` and `log` directories. There may be more directories like `py34`.
+.. note:: Ignore the `dist` and `log` directories. There may be more directories like `py37`.
 
 To activate virtualenv on Linux::
 
-    $ source .tox/py27/bin/activate
+    $ source .tox/py38/bin/activate
 
 On MS Windows::
 
-    $ source .tox/py27/Scripts/activate
+    $ source .tox/py38/Scripts/activate
 
 After you activate virtualenv, command prompt often stars showing name of the virtualenv, e.g.::
 
-    (py27) $
+    (py38) $
 
 This is shell specific behaviour.
 
@@ -191,7 +191,7 @@ To deactivate virtualenv::
 If you need to recreate the environment, you may either remove given directory,
 or ask `tox` to recreate it::
 
-    $ tox -e py27 -r
+    $ tox -e py38 -r
 
 Run all tests under one python version using `py.test`
 ------------------------------------------------------

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -15,9 +15,6 @@ from ._version import __version__
 
 def main(argv=None):
 
-    if sys.version_info < (3, 0):
-        sys.stdout = codecs.getwriter(locale.getpreferredencoding())(sys.stdout)
-
     argv = (argv or sys.argv)[1:]
 
     parser = argparse.ArgumentParser(usage=("%(prog)s [ get | groups | streams ]"))
@@ -213,13 +210,9 @@ def main(argv=None):
             traceback.format_exc(),
         ))
         # use enough backticks to properly escape the issue_info pre-formatted block
-        try:
-            backtick_count = 1 + max(
-                (len(match.group()) for match in re.finditer(r"`{3,}", issue_info)),
-            )
-        except ValueError:
-            # only needed for python 2 as later have a `default` parameter to the max function
-            backtick_count = 3
+        backtick_count = 1 + max(
+            (len(match.group()) for match in re.finditer(r"`{3,}", issue_info)),
+        )
         backticks = "`" * backtick_count + "\n"
         sys.stderr.write(backticks)
         sys.stderr.write(issue_info + "\n")

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -8,7 +8,7 @@ from collections import deque
 
 import boto3
 import botocore
-from botocore.compat import json, six, total_seconds
+from botocore.compat import json, total_seconds
 
 import jmespath
 
@@ -216,7 +216,7 @@ class AWSLogs(object):
                 if self.query is not None and message[0] == '{':
                     parsed = json.loads(event['message'])
                     message = self.query_expression.search(parsed)
-                    if not isinstance(message, six.string_types):
+                    if not isinstance(message, str):
                         message = json.dumps(message)
                 output.append(message.rstrip())
 

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -40,12 +40,23 @@ def boto3_client(aws_profile, aws_access_key_id, aws_secret_access_key, aws_sess
     credential_provider.cache = botocore.credentials.JSONFileCache(cache_dir)
 
     session = boto3.session.Session(botocore_session=core_session)
-    return session.client(
-        'logs',
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        aws_session_token=aws_session_token,
-        region_name=aws_region)
+    if aws_region:
+        # If an empty region is passed, boto will ignore the one configured for the
+        # current profile, so only pass one if it's non-null.
+        return session.client(
+            'logs',
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            region_name=aws_region,
+        )
+    else:
+        return session.client(
+            'logs',
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+        )
 
 
 class AWSLogs(object):

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,6 @@ install_requires = [
 ]
 
 
-# as of Python >= 2.7 argparse module is maintained within Python.
-extras_require = {
-    ':python_version in "2.4, 2.5, 2.6"': ['argparse>=1.1.0'],
-}
-
-
-if 'bdist_wheel' not in sys.argv and sys.version_info < (2, 7):
-    install_requires.append('argparse>1.1.0')
-
-
 setup(
     name='awslogs',
     version='0.12.0',
@@ -33,12 +23,15 @@ setup(
     keywords="aws logs cloudwatch",
     packages=find_packages(),
     platforms='any',
+    python_requires=">=3.5.*",
     install_requires=install_requires,
-    extras_require=extras_require,
     test_suite='tests',
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{26,27,33,34,35,36,lint}
+envlist = py{35,36,37,38lint}
 
 [testenv]
 commands =
@@ -13,7 +13,6 @@ commands =
     coverage report
 
 deps =
-    mock>=1.0.0; python_version<='3.3'
     coverage
     pytest
 


### PR DESCRIPTION
**awslogs** isn't picking up the region if its set in the profile, since passing `region_name=None` overrides this whatever is in settings.

Fixes  #288
Fixes  #219
Fixes  #141