### PR TITLE
Updated boto3 version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    'boto3>=1.5.0',
+    'boto3>=1.14.0',
     'jmespath>=0.7.1,<1.0.0',
     'termcolor>=1.1.0',
     'python-dateutil>=2.4.0'
@@ -11,7 +11,7 @@ install_requires = [
 
 setup(
     name='awslogs',
-    version='0.14.0',
+    version='0.14.1',
     url='https://github.com/jorgebastida/awslogs',
     license='BSD',
     author='Jorge Bastida',


### PR DESCRIPTION
Updated boto3 requirement to >=1.14.0 to fix AWS SSO issue in #310 

Issue was talked about here: https://github.com/boto/boto3/issues/2091#issuecomment-653679977

Let me know if you need anything else from me to push this through.