### PR TITLE
Run JMESPath query when JSON payload is prepended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ dist
 htmlcov/
 __pychache__
 .vscode
+venv/
+.idea/
+*.iml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.15.0
+======
+- Enhanced --query argument to match against message payloads prepended with non-JSON data.
+
 0.14.0
 ======
 - New --aws-endpoint-url option to configure awslogs to use services such localstack, fakes3, etc...

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 
 setup(
     name='awslogs',
-    version='0.14.0',
+    version='0.15.0',
     url='https://github.com/jorgebastida/awslogs',
     license='BSD',
     author='Jorge Bastida',


### PR DESCRIPTION
The --query argument is run only when the message payload starts with
the open curly brace representing a JSON object. This prevented users
from querying JSON data in messages that have prefixed data, e.g. log
level, timestamps, etc.

To work around this, we now locate the first open curly brace (if
present) and attempt to filter as JSON from that point.