### PR TITLE
Adding command line argument to disable listing of all log streams

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -147,6 +147,11 @@ def main(argv=None):
                             dest="query",
                             help="JMESPath query to use in filtering the response data")
 
+    get_parser.add_argument("--exact-stream",
+                            action='store_true',
+                            dest='exact_stream_enabled',
+                            help="Stream argument is exact match. Do not list all streams")
+
     # groups
     groups_parser = subparsers.add_parser('groups', description='List groups')
     groups_parser.set_defaults(func="list_groups")

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -80,6 +80,7 @@ class AWSLogs(object):
         self.output_timestamp_enabled = kwargs.get('output_timestamp_enabled')
         self.output_ingestion_time_enabled = kwargs.get(
             'output_ingestion_time_enabled')
+        self.exact_stream_enabled = kwargs.get('exact_stream_enabled')
         self.start = self.parse_datetime(kwargs.get('start'))
         self.end = self.parse_datetime(kwargs.get('end'))
         self.query = kwargs.get('query')
@@ -103,10 +104,16 @@ class AWSLogs(object):
             if re.match(reg, stream):
                 yield stream
 
+    def _get_streams(self, group, pattern):
+        if self.exact_stream_enabled:
+            return list([pattern])
+        else:
+            return list(self._get_streams_from_pattern(self.log_group_name, self.log_stream_name))
+
     def list_logs(self):
         streams = []
         if self.log_stream_name != self.ALL_WILDCARD:
-            streams = list(self._get_streams_from_pattern(self.log_group_name, self.log_stream_name))
+            streams = self._get_streams(self.log_group_name, self.log_stream_name)
             if len(streams) > self.FILTER_LOG_EVENTS_STREAMS_LIMIT:
                 raise exceptions.TooManyStreamsFilteredError(
                      self.log_stream_name,


### PR DESCRIPTION
In case where there are many many log streams, iterating through all of them takes forever which makes the `stream` argument useless if exact stream name is known. 

This PR adds a new command line parameter to indicate that the stream parameter is exact match and `awslogs` shouldn't iterate through all streams.

I also considered an option where first an exact match would be tried and if found use that instead of iterating. But that would be a breaking backward compatibility so I decided to use a flag.