### PR TITLE
Possibility to pass end date relative to relative to start

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -68,6 +68,11 @@ def main(argv=None):
                             dest='end',
                             help="End time")
 
+        parser.add_argument("-re", "--rend",
+                            type=str,
+                            dest='relative_end',
+                            help="Relative end time")
+
     subparsers = parser.add_subparsers()
 
     # get

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -82,6 +82,8 @@ class AWSLogs(object):
             'output_ingestion_time_enabled')
         self.start = self.parse_datetime(kwargs.get('start'))
         self.end = self.parse_datetime(kwargs.get('end'))
+        if self.end is None:
+            self.end = self.relative_to_start(kwargs.get('relative_end'))
         self.query = kwargs.get('query')
         if self.query is not None:
             self.query_expression = jmespath.compile(self.query)
@@ -299,5 +301,23 @@ class AWSLogs(object):
             if date.utcoffset != 0:
                 date = date.astimezone(tzutc())
             date = date.replace(tzinfo=None)
+
+        return int(total_seconds(date - datetime(1970, 1, 1))) * 1000
+
+
+    def relative_to_start(self, datetime_text):
+        if not datetime_text:
+            return None
+
+        ago_regexp = r'(\d+)\s?(m|minute|minutes|h|hour|hours|d|day|days|w|weeks|weeks)(?: ago)?'
+        ago_match = re.match(ago_regexp, datetime_text)
+
+        if ago_match:
+            amount, unit = ago_match.groups()
+            amount = int(amount)
+            unit = {'m': 60, 'h': 3600, 'd': 86400, 'w': 604800}[unit[0]]
+            date = datetime.fromtimestamp(self.start / 1000) + timedelta(seconds=unit * amount)
+        else:
+           raise exceptions.UnknownDateError("Wrong relative date")
 
         return int(total_seconds(date - datetime(1970, 1, 1))) * 1000


### PR DESCRIPTION
Added command line args `-re` / `--relative_end` which could be ex. `15m` which means that end date will be relative to start date
Full example:
`--start='2021-04-06T11:50:00Z' -re 15m`