### PR TITLE
Added `--stream-prefix` option for `get` command

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -147,6 +147,12 @@ def main(argv=None):
                             dest="query",
                             help="JMESPath query to use in filtering the response data")
 
+    get_parser.add_argument("-p",
+                            "--stream-prefix",
+                            action='store_true',
+                            dest="treat_stream_as_prefix",
+                            help="Treat log_stream_name as a prefix instead of as a regex")
+
     # groups
     groups_parser = subparsers.add_parser('groups', description='List groups')
     groups_parser.set_defaults(func="list_groups")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 
 setup(
     name='awslogs',
-    version='0.14.0',
+    version='0.15.0',
     url='https://github.com/jorgebastida/awslogs',
     license='BSD',
     author='Jorge Bastida',


### PR DESCRIPTION
Added a `--stream-prefix` (`-p` for short) option to `awslogs get`, to tell it to treat the `log_stream_name` argument as a name prefix instead as a regular expression.  This allows it to delegate the log stream filtering to AWS, which avoids performance problems and throttling errors for log groups with large numbers of streams.  The problem this fixes is described in #358.

Fixes #358 