### PR TITLE
Improve UTF8 support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Clément MATHIEU <clement+github@unportant.info>
 Oliver Bristow <@Code0x58>
 Wahab Ali <@wahabmk>
 Galen Huntington <@galenhuntington>
+Eduard <@eduard93>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.15.0
+======
+- Improve utf-8 support (Thanks and Eduard and Tristan-Lynass) #99 #121 #147 #156 #157 #165 #215 #273 #255 #299 #300 #339 #348 #364 #366 #376
+
 0.14.0
 ======
 - New --aws-endpoint-url option to configure awslogs to use services such localstack, fakes3, etc...

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -215,12 +215,9 @@ class AWSLogs(object):
                         message = json.dumps(message)
                 output.append(message.rstrip())
                 
-                if isinstance(output, str):
-                    output = output.encode('utf-8')
-                if isinstance(output, list):
-                    output = [y.encode('utf-8') if isinstance(y, str) else y for y in output]
-                
+                output = [m.encode('utf-8') if isinstance(m, str) else m for m in output]
                 print(b' '.join(output))
+
                 try:
                     sys.stdout.flush()
                 except IOError as e:

--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -214,8 +214,13 @@ class AWSLogs(object):
                     if not isinstance(message, str):
                         message = json.dumps(message)
                 output.append(message.rstrip())
-
-                print(' '.join(output))
+                
+                if isinstance(output, str):
+                    output = output.encode('utf-8')
+                if isinstance(output, list):
+                    output = [y.encode('utf-8') if isinstance(y, str) else y for y in output]
+                
+                print(b' '.join(output))
                 try:
                     sys.stdout.flush()
                 except IOError as e:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 
 setup(
     name='awslogs',
-    version='0.14.0',
+    version='0.15.0',
     url='https://github.com/jorgebastida/awslogs',
     license='BSD',
     author='Jorge Bastida',


### PR DESCRIPTION
If logs contained non ASCII characters, `awslogs get` could fail with:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position: character maps to <undefined>
```
In `print(' '.join(output))`

This commit forces all output to be UTF8 encoded bytes.