### PR TITLE
support python 3.12

### DIFF
--- a/awslogs/_version.py
+++ b/awslogs/_version.py
@@ -1,3 +1,3 @@
-from pkg_resources import get_distribution
+from importlib import metadata
 
-__version__ = get_distribution("awslogs").version
+__version__ = metadata.version("awslogs")


### PR DESCRIPTION
Python 3.12 has removed its bundled `setuptools` (aka `pkg_resources`): https://docs.python.org/3.12/whatsnew/3.12.html#removed
