### PR TITLE
Add support for JQ queries and JSON output

### DIFF
--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -194,6 +194,14 @@ def main(argv=None):
         help="Use all results from the jq query (by default only the first result is used)",
     )
 
+    get_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json",
+        default=False,
+        help="Output logs in JSON format for processing by other tools",
+    )
+
     # groups
     groups_parser = subparsers.add_parser("groups", description="List groups")
     groups_parser.set_defaults(func="list_groups")

--- a/awslogs/bin.py
+++ b/awslogs/bin.py
@@ -178,6 +178,22 @@ def main(argv=None):
         help="JMESPath query to use in filtering the response data",
     )
 
+    get_parser.add_argument(
+        "-j",
+        "--jq",
+        action="store",
+        dest="jq",
+        help="jq query to use in filtering the response data",
+    )
+
+    get_parser.add_argument(
+        "--jq-all",
+        action="store_true",
+        dest="jq_all",
+        default=False,
+        help="Use all results from the jq query (by default only the first result is used)",
+    )
+
     # groups
     groups_parser = subparsers.add_parser("groups", description="List groups")
     groups_parser.set_defaults(func="list_groups")
@@ -201,6 +217,10 @@ def main(argv=None):
 
     # Parse input
     options, _ = parser.parse_known_args(argv)
+
+    if getattr(options, "query", None) and getattr(options, "jq", None):
+        sys.stderr.write("Cannot use both --query and --jq at the same time\n")
+        return 1
 
     try:
         logs = AWSLogs(**vars(options))

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ install_requires = [
     "jmespath>=1.0.1",
     "termcolor>=2.4.0",
     "python-dateutil>=2.9.0",
+    "jq>=1.8.0",
 ]
 
 

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -382,6 +382,22 @@ class TestAWSLogs(unittest.TestCase):
 
     @patch("awslogs.core.boto3_client")
     @patch("sys.stdout", new_callable=StringIO)
+    @patch("os.isatty", lambda fd: True)
+    @patch("sys.stdout.isatty", lambda: True)
+    def test_main_get_jq(self, mock_stdout, botoclient):
+        self.set_json_logs(botoclient)
+        exit_code = main("awslogs get AAA DDD --jq .foo --color=always".split())
+        output = mock_stdout.getvalue()
+        expected = (
+            "\x1b[32mAAA\x1b[0m \x1b[36mDDD\x1b[0m bar\n"
+            '\x1b[32mAAA\x1b[0m \x1b[36mEEE\x1b[0m {"bar": "baz"}\n'
+            "\x1b[32mAAA\x1b[0m \x1b[36mDDD\x1b[0m Hello 3 👎\n"
+        )
+        self.assertEqual(output, expected)
+        assert exit_code == 0
+
+    @patch("awslogs.core.boto3_client")
+    @patch("sys.stdout", new_callable=StringIO)
     def test_get_nogroup(self, mock_stdout, botoclient):
         self.set_ABCDE_logs(botoclient)
         exit_code = main("awslogs get --no-group AAA DDD --color=never".split())


### PR DESCRIPTION
The first commit allows filtering logs via [jq](https://jqlang.github.io/jq/) syntax.

The second one makes this tool output JSON lines for processing with other JSON log pretty-printing utilities.