### PR TITLE
Fix UnicodeEncodeError of the issue #400

### DIFF
--- a/awslogs/core.py
+++ b/awslogs/core.py
@@ -203,7 +203,7 @@ class AWSLogs(object):
                     if not isinstance(message, str):
                         message = json.dumps(message)
                 output.append(message.rstrip())
-                print(" ".join(output))
+                print(" ".join(output).encode("utf-8"))
 
                 try:
                     sys.stdout.flush()


### PR DESCRIPTION
When running in windows powershell and pipe to a file an error similar to this occurs:
`UnicodeEncodeError: 'charmap' codec can't encode characters in position 83-120: character maps to <undefined>`

Specifying the encoding resolves the issue.

This error is discussed in https://github.com/jorgebastida/awslogs/issues/400